### PR TITLE
Connect recipe generator to OpenAI chat completions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ informadas.
    flutter run
    ```
 
-Caso não disponha de credenciais válidas da OpenAI, o aplicativo utiliza dados
-simulados para apresentar sugestões de receitas, permitindo testar o fluxo da
-interface.
+> **Atenção:** a geração das receitas depende de credenciais válidas da OpenAI.
+> Sem a configuração da chave a aplicação exibirá um alerta informando que não
+> foi possível se conectar ao ChatGPT.
 
 ## Estrutura do Projeto
 

--- a/lib/core/services/openai_service.dart
+++ b/lib/core/services/openai_service.dart
@@ -13,7 +13,9 @@ class OpenAIService {
 
   Future<String> generateRecipes(List<String> ingredients) async {
     if (!config.hasValidCredentials) {
-      return _simulateRecipes(ingredients);
+      throw const AppException(
+        'Configure sua chave da OpenAI para gerar receitas com a IA.',
+      );
     }
 
     final uri = Uri.parse('${config.openAIBaseUrl}/chat/completions');
@@ -25,6 +27,9 @@ class OpenAIService {
     final payload = jsonEncode({
       'model': config.model,
       'temperature': 0.7,
+      'response_format': {
+        'type': 'json_object',
+      },
       'messages': [
         {
           'role': 'system',
@@ -83,33 +88,5 @@ Retorne um JSON com o formato:
 }
 
 Certifique-se de que cada receita use somente os ingredientes informados (além dos genéricos permitidos).''';
-  }
-
-  String _simulateRecipes(List<String> ingredients) {
-    final safeIngredients = ingredients.isEmpty ? ['ingrediente principal'] : ingredients;
-    final sampleRecipes = {
-      'recipes': [
-        {
-          'name': 'Salada crocante de ${safeIngredients.take(1).join(', ')}',
-          'description':
-              'Uma salada leve que aproveita os ingredientes disponíveis com um toque cítrico.',
-          'ingredients': [...safeIngredients, 'Sal', 'Pimenta-do-reino', 'Azeite'],
-          'steps': [
-            'Higienize e prepare os ingredientes.',
-            'Misture tudo em uma tigela com temperos a gosto.',
-          ],
-        },
-        {
-          'name': 'Refogado rápido de ${safeIngredients.join(', ')}',
-          'description': 'Receita prática feita em uma única panela.',
-          'ingredients': [...safeIngredients, 'Óleo', 'Água'],
-          'steps': [
-            'Aqueça o óleo e doure os ingredientes aromáticos.',
-            'Adicione os demais itens e cozinhe até ficar macio.',
-          ],
-        },
-      ],
-    };
-    return const JsonEncoder.withIndent('  ').convert(sampleRecipes);
-  }
+}
 }


### PR DESCRIPTION
## Summary
- send recipe prompts to the OpenAI chat completions endpoint using JSON responses
- surface a clear error when credentials are missing instead of returning static recipes
- update the README to explain that valid OpenAI credentials are required

## Testing
- flutter analyze *(fails: Flutter SDK is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e5180bd1348328b58ed541bb2f3615