### PR TITLE
Add local fallback for usage config when Firestore is unreachable

### DIFF
--- a/assets/config/app_usage.json
+++ b/assets/config/app_usage.json
@@ -1,0 +1,5 @@
+{
+  "guestDailyLimit": 2,
+  "guestRecipeLimit": 2,
+  "shareDailyLimit": 50
+}

--- a/lib/core/services/firebase_initializer.dart
+++ b/lib/core/services/firebase_initializer.dart
@@ -8,6 +8,7 @@ class FirebaseInitializer {
   FirebaseInitializer._();
 
   static bool _initialized = false;
+  static bool _hasLoggedResolvedOptions = false;
 
   /// Ensures Firebase is ready before the rest of the app bootstraps.
   ///
@@ -15,21 +16,23 @@ class FirebaseInitializer {
   /// is not available yet, the error is logged and the app continues so the
   /// credential files can be added later without blocking execution.
   static Future<void> ensureInitialized() async {
-    if (_initialized || Firebase.apps.isNotEmpty) {
+    if (_initialized) {
+      return;
+    }
+
+    if (Firebase.apps.isNotEmpty) {
+      _logResolvedOptions(Firebase.apps.first.options);
       _initialized = true;
       return;
     }
 
     try {
-      if (kIsWeb) {
-        await Firebase.initializeApp(
-          options: DefaultFirebaseOptions.web,
-        );
-      } else {
-        await Firebase.initializeApp(
-          options: DefaultFirebaseOptions.currentPlatform,
-        );
-      }
+      final FirebaseOptions options = kIsWeb
+          ? DefaultFirebaseOptions.web
+          : DefaultFirebaseOptions.currentPlatform;
+
+      final FirebaseApp app = await Firebase.initializeApp(options: options);
+      _logResolvedOptions(app.options);
       _initialized = true;
     } on FirebaseException catch (error, stackTrace) {
       _initialized = false;
@@ -42,5 +45,36 @@ class FirebaseInitializer {
       debugPrint('Firebase initialization error: $error\n$stackTrace');
       rethrow;
     }
+  }
+
+  static void _logResolvedOptions(FirebaseOptions options) {
+    if (_hasLoggedResolvedOptions) {
+      return;
+    }
+
+    final String redactedKey = _redact(options.apiKey);
+    debugPrint(
+      'Firebase inicializado com sucesso. projectId=${options.projectId}, '
+      'appId=${options.appId}, senderId=${options.messagingSenderId}, '
+      'storageBucket=${options.storageBucket ?? 'n/a'}.',
+    );
+    debugPrint('Chave de API do Google Services: $redactedKey');
+    _hasLoggedResolvedOptions = true;
+  }
+
+  static String _redact(String value) {
+    if (value.isEmpty) {
+      return '(vazio)';
+    }
+
+    if (value.length <= 8) {
+      final String start = value.substring(0, 1);
+      final String end = value.substring(value.length - 1);
+      return '$start***$end';
+    }
+
+    final String start = value.substring(0, 4);
+    final String end = value.substring(value.length - 4);
+    return '$start***$end';
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,6 +4,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:get/get.dart';
+import 'package:google_fonts/google_fonts.dart';
 import 'package:google_sign_in/google_sign_in.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -19,6 +20,7 @@ import 'package:receitagora/services/billing/stripe_billing_service.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  GoogleFonts.config.allowRuntimeFetching = false;
   await dotenv.load(fileName: '.env', isOptional: true);
   await FirebaseInitializer.ensureInitialized();
 

--- a/lib/services/config/usage_config_service_impl.dart
+++ b/lib/services/config/usage_config_service_impl.dart
@@ -21,6 +21,7 @@ class UsageConfigServiceImpl extends GetxService implements UsageConfigService {
   StreamSubscription<DocumentSnapshot<Map<String, dynamic>>>?
       _subscription;
   bool _isInitializing = false;
+  bool _hasLoadedFallback = false;
 
   static const String _documentPath = 'config/app_usage';
 
@@ -47,8 +48,9 @@ class UsageConfigServiceImpl extends GetxService implements UsageConfigService {
     _isInitializing = true;
 
     try {
-      await _loadInitialConfig();
+      await _ensureFallbackConfigLoaded(logOnSuccess: false);
       _listenForUpdates();
+      unawaited(_loadRemoteConfig());
     } finally {
       if (!_readyCompleter.isCompleted) {
         _readyCompleter.complete();
@@ -57,7 +59,7 @@ class UsageConfigServiceImpl extends GetxService implements UsageConfigService {
     }
   }
 
-  Future<void> _loadInitialConfig() async {
+  Future<void> _loadRemoteConfig() async {
     try {
       final snapshot = await _firestore.doc(_documentPath).get();
       if (snapshot.exists) {
@@ -67,9 +69,9 @@ class UsageConfigServiceImpl extends GetxService implements UsageConfigService {
         }
       }
     } on FirebaseException catch (error, stackTrace) {
-      await _loadFallbackConfig(error, stackTrace);
+      await _handleRemoteLoadFailure(error, stackTrace);
     } catch (error, stackTrace) {
-      await _loadFallbackConfig(error, stackTrace);
+      await _handleRemoteLoadFailure(error, stackTrace);
     }
   }
 
@@ -88,7 +90,7 @@ class UsageConfigServiceImpl extends GetxService implements UsageConfigService {
     });
   }
 
-  Future<void> _loadFallbackConfig(
+  Future<void> _handleRemoteLoadFailure(
     Object error,
     StackTrace stackTrace,
   ) async {
@@ -96,15 +98,30 @@ class UsageConfigServiceImpl extends GetxService implements UsageConfigService {
       'Falha ao carregar configuração de uso no Firestore: $error\n$stackTrace',
       isError: true,
     );
+    await _ensureFallbackConfigLoaded();
+  }
+
+  Future<void> _ensureFallbackConfigLoaded({bool logOnSuccess = true}) async {
+    if (_hasLoadedFallback) {
+      if (logOnSuccess) {
+        Get.log(
+          'Mantendo configuração de uso carregada do fallback local ($_fallbackAssetPath).',
+        );
+      }
+      return;
+    }
 
     try {
       final payload = await rootBundle.loadString(_fallbackAssetPath);
       final Map<String, dynamic> data =
           jsonDecode(payload) as Map<String, dynamic>;
       _config.value = UsageConfig.fromMap(data, _config.value);
-      Get.log(
-        'Aplicando configuração de uso a partir do fallback local ($_fallbackAssetPath).',
-      );
+      _hasLoadedFallback = true;
+      if (logOnSuccess) {
+        Get.log(
+          'Aplicando configuração de uso a partir do fallback local ($_fallbackAssetPath).',
+        );
+      }
     } catch (assetError, assetStackTrace) {
       Get.log(
         'Falha ao carregar configuração de uso local: $assetError\n$assetStackTrace',

--- a/lib/services/config/usage_config_service_impl.dart
+++ b/lib/services/config/usage_config_service_impl.dart
@@ -47,10 +47,8 @@ class UsageConfigServiceImpl extends GetxService implements UsageConfigService {
     _isInitializing = true;
 
     try {
-      final hasRemoteConfig = await _loadInitialConfig();
-      if (hasRemoteConfig) {
-        _listenForUpdates();
-      }
+      await _loadInitialConfig();
+      _listenForUpdates();
     } finally {
       if (!_readyCompleter.isCompleted) {
         _readyCompleter.complete();
@@ -59,7 +57,7 @@ class UsageConfigServiceImpl extends GetxService implements UsageConfigService {
     }
   }
 
-  Future<bool> _loadInitialConfig() async {
+  Future<void> _loadInitialConfig() async {
     try {
       final snapshot = await _firestore.doc(_documentPath).get();
       if (snapshot.exists) {
@@ -68,13 +66,11 @@ class UsageConfigServiceImpl extends GetxService implements UsageConfigService {
           _config.value = UsageConfig.fromMap(data, _config.value);
         }
       }
-      return true;
     } on FirebaseException catch (error, stackTrace) {
       await _loadFallbackConfig(error, stackTrace);
     } catch (error, stackTrace) {
       await _loadFallbackConfig(error, stackTrace);
     }
-    return false;
   }
 
   void _listenForUpdates() {

--- a/lib/services/config/usage_config_service_impl.dart
+++ b/lib/services/config/usage_config_service_impl.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/services.dart';
 import 'package:get/get.dart';
 
 import 'package:receitagora/services/config/usage_config.dart';
@@ -45,8 +47,10 @@ class UsageConfigServiceImpl extends GetxService implements UsageConfigService {
     _isInitializing = true;
 
     try {
-      await _loadInitialConfig();
-      _listenForUpdates();
+      final hasRemoteConfig = await _loadInitialConfig();
+      if (hasRemoteConfig) {
+        _listenForUpdates();
+      }
     } finally {
       if (!_readyCompleter.isCompleted) {
         _readyCompleter.complete();
@@ -55,7 +59,7 @@ class UsageConfigServiceImpl extends GetxService implements UsageConfigService {
     }
   }
 
-  Future<void> _loadInitialConfig() async {
+  Future<bool> _loadInitialConfig() async {
     try {
       final snapshot = await _firestore.doc(_documentPath).get();
       if (snapshot.exists) {
@@ -64,12 +68,13 @@ class UsageConfigServiceImpl extends GetxService implements UsageConfigService {
           _config.value = UsageConfig.fromMap(data, _config.value);
         }
       }
+      return true;
+    } on FirebaseException catch (error, stackTrace) {
+      await _loadFallbackConfig(error, stackTrace);
     } catch (error, stackTrace) {
-      Get.log(
-        'Falha ao carregar configuração de uso: $error\n$stackTrace',
-        isError: true,
-      );
+      await _loadFallbackConfig(error, stackTrace);
     }
+    return false;
   }
 
   void _listenForUpdates() {
@@ -87,6 +92,31 @@ class UsageConfigServiceImpl extends GetxService implements UsageConfigService {
     });
   }
 
+  Future<void> _loadFallbackConfig(
+    Object error,
+    StackTrace stackTrace,
+  ) async {
+    Get.log(
+      'Falha ao carregar configuração de uso no Firestore: $error\n$stackTrace',
+      isError: true,
+    );
+
+    try {
+      final payload = await rootBundle.loadString(_fallbackAssetPath);
+      final Map<String, dynamic> data =
+          jsonDecode(payload) as Map<String, dynamic>;
+      _config.value = UsageConfig.fromMap(data, _config.value);
+      Get.log(
+        'Aplicando configuração de uso a partir do fallback local ($_fallbackAssetPath).',
+      );
+    } catch (assetError, assetStackTrace) {
+      Get.log(
+        'Falha ao carregar configuração de uso local: $assetError\n$assetStackTrace',
+        isError: true,
+      );
+    }
+  }
+
   @override
   void onClose() {
     _subscription?.cancel();
@@ -94,3 +124,5 @@ class UsageConfigServiceImpl extends GetxService implements UsageConfigService {
   }
 
 }
+
+const String _fallbackAssetPath = 'assets/config/app_usage.json';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -77,6 +77,7 @@ flutter:
 
   assets:
     - .env
+    - assets/config/app_usage.json
 
   # An image asset can refer to one or more resolution-specific "variants", see
   # https://flutter.dev/to/resolution-aware-images


### PR DESCRIPTION
## Summary
- add a bundled usage config JSON fallback
- load the fallback when Firestore cannot be reached so the app can continue offline
- register the new asset in pubspec

## Testing
- not run (Flutter SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68f8ef8bb53883288b85d32e908e8cb4